### PR TITLE
Update the name of learning club sign up channel

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ follow these steps:
    [`#🤖-talk-to-bots`](https://kcd.im/discord-talk-to-bots) channel in the
    [KCD Discord](https://kentcdodds.com/discord) and type:
    `?clubs create FORM_LINK` to get it listed in the
-   [`#📝-active-clubs`](https://kcd.im/discord-active-clubs).
+   [`#📝-open-clubs`](https://kcd.im/discord-active-clubs).
 
 Learn more about this process and how these clubs work at
 [kentcdodds.com/clubs](https://kentcdodds.com/clubs).


### PR DESCRIPTION
* Name changed to remove channel confusion

Per: https://discordapp.com/channels/715220730605731931/715225293471744021/760321169499881522

- [x] Check that the link still navigates to the right discord channel 